### PR TITLE
feat: make nestedindex kernel work with virtual arrays

### DIFF
--- a/src/awkward_zipper/kernels.py
+++ b/src/awkward_zipper/kernels.py
@@ -87,10 +87,9 @@ def nestedindex(indices):
         for i, idx in enumerate(indices):
             if "__doc__" in parameters:
                 parameters["__doc__"] += " and "
-                parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
             else:
                 parameters["__doc__"] = "nested from "
-                parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
+            parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
             # flatten the index
             indices[i] = awkward.Array(idx.layout.content)
 
@@ -138,10 +137,10 @@ def nestedindex(indices):
         for idx in indices:
             if "__doc__" in parameters:
                 parameters["__doc__"] += " and "
-                parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
             else:
                 parameters["__doc__"] = "nested from "
-                parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
+
+            parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
         return parameters
 
     if not all(

--- a/src/awkward_zipper/layouts/nanoaod.py
+++ b/src/awkward_zipper/layouts/nanoaod.py
@@ -14,6 +14,7 @@ from awkward_zipper.kernels import (
     distinct_children_deep,
     distinct_parent,
     local2globalindex,
+    nestedindex,
 )
 from awkward_zipper.layouts.base import BaseLayoutBuilder
 
@@ -283,6 +284,13 @@ class NanoAOD(BaseLayoutBuilder):
             arr_indexer = _non_materializing_get_field(array, indexer)
             arr_target = _non_materializing_get_field(array, "n" + target)
             new_fields[indexer + "G"] = local2globalindex(arr_indexer, arr_target)
+
+        # Create nested indexer from Idx1, Idx2, ... arrays
+        for name, indexers in self.nested_items.items():
+            if all(idx in new_fields for idx in indexers):
+                new_fields[name] = nestedindex(
+                    [_non_materializing_get_field(new_fields, idx) for idx in indexers]
+                )
 
         # TODO: make those kernels work with virtual arrays
         # # Create nested indexer from Idx1, Idx2, ... arrays


### PR DESCRIPTION
Taking the restrictions of Virtual Array generator into account (that it has to return a `NumpyArray`) I've broken the `nestedindex` function into smaller pieces to construct final array's **content**, **offsets** and **parameters** separately. 

`_nestedindex` is a function for eager case

`_nestedindex_content` returns **content** as soon as it constructs it

`_get_nested_index_offsets` constructs **offsets** from the **content**

`_combine_parameters` combines **parameters** of index[0] and index[1]

And this whole thing does work. However I wonder if there is a simpler way to do this, without creating separate functions for virtual arrays construction. Is there maybe a way to have only one `lambda` function that would return **content** array, **offsets** array and **parameters** all at once?