### PR TITLE
feat: simplify the kernels

### DIFF
--- a/src/awkward_zipper/kernels.py
+++ b/src/awkward_zipper/kernels.py
@@ -69,9 +69,7 @@ def local2globalindex(index, counts):
 
     # Check if VirtualArray
     index_data = None
-    if (not index.layout.is_all_materialized) or (
-        not counts.layout.is_all_materialized
-    ):
+    if not all(awkward.to_layout(_).is_all_materialized for _ in (index, counts)):
         index_data = index.layout.content.data
 
     # resulting global index will have the same offsets as local index
@@ -113,7 +111,7 @@ def nestedindex(indices):
     def _nestedindex_content(indices):
         # return awkward.concatenate([idx[:, None] for idx in indexers], axis=1)
         flat_indices = []
-        for i, idx in enumerate(indices):
+        for idx in indices:
             # flatten the index
             flat_indices.append(awkward.Array(idx.layout.content))
 
@@ -152,7 +150,7 @@ def nestedindex(indices):
 
     # Check if VirtualArray
     index_data = None
-    if not all(awkward.to_layout(index).is_all_materialized for index in indices):
+    if not all(awkward.to_layout(_).is_all_materialized for _ in indices):
         index_data = indices[0].layout.content.data
 
     # store offsets to later reapply them to the arrays

--- a/src/awkward_zipper/kernels.py
+++ b/src/awkward_zipper/kernels.py
@@ -245,6 +245,7 @@ def counts2nestedindex(local_counts, target_offsets):
     )
 
 
+# TODO: add dispatch_wrapper decorator for this function too
 def counts2offsets(counts):
     # Cumulative sum of counts
     def _counts2offsets(counts):
@@ -261,10 +262,11 @@ def counts2offsets(counts):
         and not counts.is_materialized
     ):
         virtual_array = counts
-    elif not counts.layout.is_all_materialized:
+    elif isinstance(counts, awkward.Array) and not counts.layout.is_all_materialized:
         virtual_array = counts.layout.data
     else:
         virtual_array = None
+
     if virtual_array is not None:
         return awkward._nplikes.virtual.VirtualArray(
             nplike=virtual_array._nplike,


### PR DESCRIPTION
use a wrapper for every kernel's internal function which will work both for VirtualArrays and materialized (eager) arrays