### PR TITLE
chore: make dependencies better for installation and test against latest coffea

### DIFF
--- a/docs/benchmarks/compare_histograms_made_with_coffea_and_zipper.ipynb
+++ b/docs/benchmarks/compare_histograms_made_with_coffea_and_zipper.ipynb
@@ -411,7 +411,7 @@
         "    # Create a TTree from root\n",
         "    tree = uproot.open(file)[\"Events\"]\n",
         "    # TTree -> awkward.Array[awkward.Record[str, awkward.Array]]\n",
-        "    array = tree.virtual_arrays(ak_add_doc=True, access_log=access_log)\n",
+        "    array = tree.arrays(virtual=True, ak_add_doc=True, access_log=access_log)\n",
         "\n",
         "    # construct an awkward array using awkward-zipper\n",
         "    restructure = awkward_zipper.NanoAOD(version=\"latest\")\n",

--- a/docs/benchmarks/simple_test_of_coffea_and_zipper_speeds.ipynb
+++ b/docs/benchmarks/simple_test_of_coffea_and_zipper_speeds.ipynb
@@ -370,7 +370,7 @@
         "    # Create a TTree from root\n",
         "    tree = uproot.open(file)[\"Events\"]\n",
         "    # TTree -> awkward.Array[awkward.Record[str, awkward.Array]]\n",
-        "    array = tree.virtual_arrays(ak_add_doc=True, access_log=access_log)\n",
+        "    array = tree.arrays(virtual=True, ak_add_doc=True, access_log=access_log)\n",
         "\n",
         "    # construct an awkward array using awkward-zipper\n",
         "    restructure = awkward_zipper.NanoAOD(version=\"latest\")\n",

--- a/docs/notebooks/Usage_example_of_awkward_zipper.ipynb
+++ b/docs/notebooks/Usage_example_of_awkward_zipper.ipynb
@@ -1250,7 +1250,7 @@
     "# to load virtual arrays\n",
     "access_log = []  # which of the data was materialized\n",
     "# TTree -> awkward.Array[awkward.Record[str, awkward.Array]]\n",
-    "array = tree.virtual_arrays(ak_add_doc=True, access_log=access_log)"
+    "array = tree.arrays(virtual=True, ak_add_doc=True, access_log=access_log)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 dependencies = [
-    "awkward@git+https://github.com/scikit-hep/awkward@main",
+    "awkward >=2.8.8",
     "vector",
     "numba",
 ]
@@ -40,7 +40,8 @@ dev = [
     "pre_commit",
     "mypy",
     # use a version of coffea where awkward-zipper was not a part of it
-    "coffea==2025.7.0",
+    "coffea",
+    # change to release as soon as the PR exists in a release
     "uproot@git+https://github.com/scikit-hep/uproot5@pfackeldey/uproot_lazy",
     "requests",
     "aiohttp",

--- a/tests/test_eager.py
+++ b/tests/test_eager.py
@@ -102,7 +102,10 @@ def test_behaviors():
 
     # don't take Systematics into account
     for behavior in diff.copy():
-        if any(string in behavior for string in ("Systematic", "UpDownSystematic")):
+        if any(
+            string in behavior
+            for string in ("Systematic", "UpDownSystematic", "UpDownMultiSystematic")
+        ):
             diff.remove(behavior)
 
     assert len(diff) == 0

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -11,7 +11,8 @@ file_name = "tests/samples/nano_dy.root"
 tree = uproot.open(file_name)["Events"]
 # TTree -> awkward.Array[awkward.Record[str, awkward.Array]]
 access_log_zipper = []
-array = tree.virtual_arrays(
+array = tree.arrays(
+    virtual=True,
     ak_add_doc={"__doc__": "title", "typename": "typename"},
     access_log=access_log_zipper,
 )

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -116,7 +116,10 @@ def test_behaviors():
 
     # don't take Systematics into account
     for behavior in diff.copy():
-        if any(string in behavior for string in ("Systematic", "UpDownSystematic")):
+        if any(
+            string in behavior
+            for string in ("Systematic", "UpDownSystematic", "UpDownMultiSystematic")
+        ):
             diff.remove(behavior)
 
     assert len(diff) == 0


### PR DESCRIPTION
We should be using an awkward release at this point and also test with latest coffea until it depends on awkward-zipper.