### PR TITLE
feat: implement Delphes schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: "v5.0.0"
     hooks:
       - id: check-added-large-files
+        args: ["--maxkb=6000"]
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks

--- a/src/awkward_zipper/__init__.py
+++ b/src/awkward_zipper/__init__.py
@@ -1,8 +1,10 @@
 from awkward_zipper.layouts.base import BaseLayoutBuilder
+from awkward_zipper.layouts.delphes import Delphes
 from awkward_zipper.layouts.nanoaod import NanoAOD, PFNanoAOD, ScoutingNanoAOD
 
 __all__ = [
     "BaseLayoutBuilder",
+    "Delphes",
     "NanoAOD",
     "PFNanoAOD",
     "ScoutingNanoAOD",

--- a/src/awkward_zipper/awkward_util.py
+++ b/src/awkward_zipper/awkward_util.py
@@ -31,6 +31,12 @@ def _non_materializing_get_field(record, field):
     return awkward.Array(record._contents[index])
 
 
+def _jagged_content(arr):
+    """Flat content of a single-jagged (ListOffsetArray) array, without materializing."""
+    layout = arr.layout if isinstance(arr, awkward.Array) else arr
+    return layout.content
+
+
 def _maybe_raw_generator(buffer):
     if isinstance(buffer, awkward._nplikes.virtual.VirtualNDArray):
         if hasattr(buffer._generator, "__awkward_raw_generator__"):

--- a/src/awkward_zipper/behaviors/delphes.py
+++ b/src/awkward_zipper/behaviors/delphes.py
@@ -1,0 +1,312 @@
+"""Mixins for the Delphes schema
+
+See https://delphes.github.io/workbook/root-tree-description/ for details.
+"""
+
+import awkward
+
+from awkward_zipper.behaviors import base, candidate, vector
+
+behavior = {}
+behavior.update(base.behavior)
+# vector behavior is included in candidate behavior
+behavior.update(candidate.behavior)
+
+
+class DelphesEvents(behavior["NanoEvents"]):
+    def __repr__(self):
+        return f"<Delphes event {self.Event.Number}>"
+
+
+behavior["NanoEvents"] = DelphesEvents
+
+
+def _set_repr_name(classname):
+    def namefcn(self):
+        return classname
+
+    behavior[("__typestr__", classname)] = classname[0].lower() + classname[1:]
+    behavior[classname].__repr__ = namefcn
+
+
+@awkward.mixin_class(behavior)
+class Event: ...
+
+
+_set_repr_name("Event")
+
+
+@awkward.mixin_class(behavior)
+class LHEFEvent(Event): ...
+
+
+_set_repr_name("LHEFEvent")
+
+
+@awkward.mixin_class(behavior)
+class HepMCEvent(Event): ...
+
+
+_set_repr_name("HepMCEvent")
+
+
+@awkward.mixin_class(behavior)
+class LHCOEvent(Event): ...
+
+
+_set_repr_name("LHCOEvent")
+
+
+@awkward.mixin_class(behavior)
+class Weight(base.NanoCollection): ...
+
+
+_set_repr_name("Weight")
+
+
+@awkward.mixin_class(behavior)
+class WeightLHEF(Event): ...
+
+
+_set_repr_name("WeightLHEF")
+
+
+@awkward.mixin_class(behavior)
+class Rho(base.NanoCollection): ...
+
+
+_set_repr_name("Rho")
+
+
+@awkward.mixin_class(behavior)
+class ScalarHT(base.NanoCollection): ...
+
+
+_set_repr_name("ScalarHT")
+
+
+behavior.update(
+    awkward._util.copy_behaviors("SphericalThreeVector", "MissingET", behavior)
+)
+
+
+@awkward.mixin_class(behavior)
+class MissingET(vector.SphericalThreeVector, base.NanoCollection): ...
+
+
+_set_repr_name("MissingET")
+
+
+MissingETArray.ProjectionClass2D = vector.PolarTwoVectorArray  # noqa: F821
+MissingETArray.ProjectionClass3D = MissingETArray  # noqa: F821
+MissingETArray.ProjectionClass4D = vector.LorentzVectorArray  # noqa: F821
+MissingETArray.MomentumClass = MissingETArray  # noqa: F821
+MissingETRecord.ProjectionClass2D = vector.PolarTwoVectorRecord  # noqa: F821
+MissingETRecord.ProjectionClass3D = MissingETRecord  # noqa: F821
+MissingETRecord.ProjectionClass4D = vector.LorentzVectorRecord  # noqa: F821
+MissingETRecord.MomentumClass = MissingETRecord  # noqa: F821
+
+
+behavior.update(awkward._util.copy_behaviors("LorentzVector", "Vertex", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Vertex(vector.LorentzVector):
+    """Generic vertex collection that has Lorentz vector properties"""
+
+
+_set_repr_name("Vertex")
+
+VertexArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+VertexArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+VertexArray.ProjectionClass4D = VertexArray  # noqa: F821
+VertexArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+VertexRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+VertexRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+VertexRecord.ProjectionClass4D = VertexRecord  # noqa: F821
+VertexRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(
+    awkward._util.copy_behaviors("PtEtaPhiMLorentzVector", "Particle", behavior)
+)
+
+
+@awkward.mixin_class(behavior)
+class Particle(vector.PtEtaPhiMLorentzVector):
+    """Generic particle collection that has Lorentz vector properties
+
+    The following branches are not used:
+
+     - E: particle energy
+     - Px: particle momentum vector (x component)
+     - Py: particle momentum vector (y component)
+     - Pz: particle momentum vector (z component)
+
+     - P: particle momentum
+     - Rapidity: particle rapidity
+
+     - T: particle vertex position (t component)
+     - X: particle vertex position (x component)
+     - Y: particle vertex position (y component)
+     - Z: particle vertex position (z component)
+    """
+
+
+_set_repr_name("Particle")
+
+ParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+ParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+ParticleArray.ProjectionClass4D = ParticleArray  # noqa: F821
+ParticleArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+ParticleRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+ParticleRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+ParticleRecord.ProjectionClass4D = ParticleRecord  # noqa: F821
+ParticleRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("Particle", "MasslessParticle", behavior))
+
+
+@awkward.mixin_class(behavior)
+class MasslessParticle(Particle, base.NanoCollection): ...
+
+
+_set_repr_name("MasslessParticle")
+
+MasslessParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+MasslessParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+MasslessParticleArray.ProjectionClass4D = MasslessParticleArray  # noqa: F821
+MasslessParticleArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+MasslessParticleRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+MasslessParticleRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+MasslessParticleRecord.ProjectionClass4D = MasslessParticleRecord  # noqa: F821
+MasslessParticleRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("MasslessParticle", "Photon", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Photon(MasslessParticle, base.NanoCollection): ...
+
+
+_set_repr_name("Photon")
+
+PhotonArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+PhotonArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+PhotonArray.ProjectionClass4D = PhotonArray  # noqa: F821
+PhotonArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+PhotonRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+PhotonRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+PhotonRecord.ProjectionClass4D = PhotonRecord  # noqa: F821
+PhotonRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("MasslessParticle", "Electron", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Electron(MasslessParticle, base.NanoCollection): ...
+
+
+_set_repr_name("Electron")
+
+ElectronArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+ElectronArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+ElectronArray.ProjectionClass4D = ElectronArray  # noqa: F821
+ElectronArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+ElectronRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+ElectronRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+ElectronRecord.ProjectionClass4D = ElectronRecord  # noqa: F821
+ElectronRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("MasslessParticle", "Muon", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Muon(MasslessParticle, base.NanoCollection): ...
+
+
+_set_repr_name("Muon")
+
+MuonArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+MuonArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+MuonArray.ProjectionClass4D = MuonArray  # noqa: F821
+MuonArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+MuonRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+MuonRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+MuonRecord.ProjectionClass4D = MuonRecord  # noqa: F821
+MuonRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("Particle", "Jet", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Jet(Particle, base.NanoCollection): ...
+
+
+_set_repr_name("Jet")
+
+JetArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+JetArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+JetArray.ProjectionClass4D = JetArray  # noqa: F821
+JetArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+JetRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+JetRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+JetRecord.ProjectionClass4D = JetRecord  # noqa: F821
+JetRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("Particle", "Track", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Track(Particle, base.NanoCollection): ...
+
+
+_set_repr_name("Track")
+
+TrackArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+TrackArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+TrackArray.ProjectionClass4D = TrackArray  # noqa: F821
+TrackArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+TrackRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+TrackRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+TrackRecord.ProjectionClass4D = TrackRecord  # noqa: F821
+TrackRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+behavior.update(awkward._util.copy_behaviors("MasslessParticle", "Tower", behavior))
+
+
+@awkward.mixin_class(behavior)
+class Tower(MasslessParticle, base.NanoCollection): ...
+
+
+_set_repr_name("Tower")
+
+TowerArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
+TowerArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
+TowerArray.ProjectionClass4D = TowerArray  # noqa: F821
+TowerArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
+TowerRecord.ProjectionClass2D = vector.TwoVectorRecord  # noqa: F821
+TowerRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
+TowerRecord.ProjectionClass4D = TowerRecord  # noqa: F821
+TowerRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
+
+
+__all__ = [
+    "DelphesEvents",
+    "Electron",
+    "Event",
+    "HepMCEvent",
+    "Jet",
+    "LHCOEvent",
+    "LHEFEvent",
+    "MissingET",
+    "Muon",
+    "Particle",
+    "Photon",
+    "Rho",
+    "ScalarHT",
+    "Tower",
+    "Track",
+    "Vertex",
+    "Weight",
+    "WeightLHEF",
+]

--- a/src/awkward_zipper/kernels.py
+++ b/src/awkward_zipper/kernels.py
@@ -359,6 +359,43 @@ def full_like_from_counts(counts, fill_value):
     )
 
 
+def met_to_rho(met_content, eta_content):
+    """Compute ``rho = met * cosh(eta)`` on flat contents, lazily.
+
+    Mirrors coffea's ``met_to_rho`` transform. ``met_content`` and
+    ``eta_content`` are flat ``NumpyArray`` contents; the result is returned as a
+    flat ``NumpyArray`` content and is only evaluated when the buffer is read.
+    """
+
+    def _compute(met, eta):
+        return ensure_array(met) * np.cosh(ensure_array(eta))
+
+    met_data = met_content.data
+    eta_data = eta_content.data
+    is_virtual = awkward._nplikes.virtual.VirtualNDArray
+    met_virtual = isinstance(met_data, is_virtual) and not met_data.is_materialized
+    eta_virtual = isinstance(eta_data, is_virtual) and not eta_data.is_materialized
+
+    if met_virtual or eta_virtual:
+        base = met_data if met_virtual else eta_data
+        result_dtype = np.result_type(met_content.dtype, eta_content.dtype)
+
+        def _materialize(x):
+            return x.materialize() if isinstance(x, is_virtual) else x
+
+        result = awkward._nplikes.virtual.VirtualNDArray(
+            nplike=base._nplike,
+            shape=(awkward._nplikes.shape.unknown_length,),
+            dtype=result_dtype,
+            generator=lambda: _compute(_materialize(met_data), _materialize(eta_data)),
+            shape_generator=None,
+        )
+    else:
+        result = _compute(met_data, eta_data)
+
+    return awkward.contents.NumpyArray(result)
+
+
 @dispatch_wrap
 @numba.njit
 def _distinct_parent_kernel(allpart_parent, allpart_pdg):

--- a/src/awkward_zipper/layouts/delphes.py
+++ b/src/awkward_zipper/layouts/delphes.py
@@ -30,6 +30,19 @@ _LIST_LIKE = (
 )
 
 
+def _maybe_unknown_length(contents, eager_length_fn):
+    """Length for a ``RecordArray``: ``unknown_length`` while any content is
+    virtual (a concrete length would slice the contents and materialize their
+    shape generators), else the concrete length from ``eager_length_fn()``.
+
+    ``eager_length_fn`` is a callable so the concrete length (which itself can
+    materialize) is only computed once everything is already materialized.
+    """
+    if all(c.is_all_materialized for c in contents):
+        return eager_length_fn()
+    return awkward._nplikes.shape.unknown_length
+
+
 def _lorentz_from_tlv(content):
     """Convert a ROOT ``TLorentzVector`` record content to a ``LorentzVector``.
 
@@ -49,7 +62,7 @@ def _lorentz_from_tlv(content):
         return awkward.contents.RecordArray(
             [fX, fY, fZ, fE],
             ["x", "y", "z", "t"],
-            length=content.length,
+            length=_maybe_unknown_length([fX, fY, fZ, fE], lambda: content.length),
             parameters={"__record__": "LorentzVector"},
         )
     if isinstance(content, _LIST_LIKE):
@@ -71,10 +84,11 @@ def _strip_tref(content):
         keep = [f for f in content.fields if not f.startswith("@")]
         if len(keep) < len(content.fields):
             indices = [content.fields.index(f) for f in keep]
+            kept = [content.contents[i] for i in indices]
             return awkward.contents.RecordArray(
-                [content.contents[i] for i in indices],
+                kept,
                 keep,
-                length=content.length,
+                length=_maybe_unknown_length(kept, lambda: content.length),
                 parameters=content.parameters,
             )
     if isinstance(content, _LIST_LIKE):
@@ -239,7 +253,9 @@ class Delphes(BaseLayoutBuilder):
             record = awkward.contents.RecordArray(
                 _content,
                 _fields,
-                length=_total_items(offsets),
+                length=_maybe_unknown_length(
+                    _content, lambda offsets=offsets: _total_items(offsets)
+                ),
                 parameters={"__record__": mixin, "collection_name": name},
             )
 

--- a/src/awkward_zipper/layouts/delphes.py
+++ b/src/awkward_zipper/layouts/delphes.py
@@ -1,0 +1,273 @@
+import typing as tp
+
+import awkward
+import numpy as np
+
+from awkward_zipper.awkward_util import (
+    _jagged_content,
+    _non_materializing_get_field,
+    _rewrap,
+)
+from awkward_zipper.kernels import counts2offsets, full_like_from_counts, met_to_rho
+from awkward_zipper.layouts.base import BaseLayoutBuilder
+
+
+def _total_items(offsets):
+    """Number of flat items implied by an offsets array (``offsets[-1]``).
+
+    Returns an unknown length when the offsets are virtual, so that reading it
+    does not materialize the counts branch.
+    """
+    if isinstance(offsets, np.ndarray):
+        return int(offsets[-1])
+    return awkward._nplikes.shape.unknown_length
+
+
+_LIST_LIKE = (
+    awkward.contents.ListOffsetArray,
+    awkward.contents.ListArray,
+    awkward.contents.RegularArray,
+)
+
+
+def _lorentz_from_tlv(content):
+    """Convert a ROOT ``TLorentzVector`` record content to a ``LorentzVector``.
+
+    Matches a ``RecordArray`` with ``fE`` and ``fP`` (a ``TVector3`` with
+    ``fX``/``fY``/``fZ``) and returns ``{x, y, z, t}``. Recurses through
+    list-like wrappers. Returns ``None`` when nothing is converted, so callers
+    can leave unrelated leaves untouched.
+    """
+    if isinstance(content, awkward.contents.RecordArray) and {"fE", "fP"} <= set(
+        content.fields
+    ):
+        fP = content.contents[content.fields.index("fP")]
+        fE = content.contents[content.fields.index("fE")]
+        fX = fP.contents[fP.fields.index("fX")]
+        fY = fP.contents[fP.fields.index("fY")]
+        fZ = fP.contents[fP.fields.index("fZ")]
+        return awkward.contents.RecordArray(
+            [fX, fY, fZ, fE],
+            ["x", "y", "z", "t"],
+            length=content.length,
+            parameters={"__record__": "LorentzVector"},
+        )
+    if isinstance(content, _LIST_LIKE):
+        inner = _lorentz_from_tlv(content.content)
+        if inner is not None:
+            return content.copy(content=inner)
+    return None
+
+
+def _strip_tref(content):
+    """Drop the ``@other*`` members of a ROOT ``TRef`` record, keeping only ``ref``.
+
+    uproot's eager reader already reduces a ``TRef`` to ``{ref}`` (as does
+    coffea), but the ``virtual=True`` reader keeps the full
+    ``{ref, @other1, @other2}`` whose ``@other`` buffers cannot be materialized.
+    Returns ``None`` when there is nothing to strip.
+    """
+    if isinstance(content, awkward.contents.RecordArray):
+        keep = [f for f in content.fields if not f.startswith("@")]
+        if len(keep) < len(content.fields):
+            indices = [content.fields.index(f) for f in keep]
+            return awkward.contents.RecordArray(
+                [content.contents[i] for i in indices],
+                keep,
+                length=content.length,
+                parameters=content.parameters,
+            )
+    if isinstance(content, _LIST_LIKE):
+        inner = _strip_tref(content.content)
+        if inner is not None:
+            return content.copy(content=inner)
+    return None
+
+
+class Delphes(BaseLayoutBuilder):
+    """Delphes layout builder
+
+    The Delphes layout is built from all branches found in the supplied file,
+    based on the naming pattern of the branches. Any branches named
+    ``{name}_size`` are counts branches, converted to offsets. Every Delphes
+    object collection is a jagged list of records; the split leaf branches
+    (``{name}.{var}``) are grouped under the collection ``{name}`` and given the
+    aliases required by the vector/candidate behaviors (``pt``, ``eta``, ``phi``,
+    ``mass``, ``rho``).
+
+    A companion ``{name}.offsets`` field is emitted for each collection (matching
+    coffea). Collections stored as length-1 vectors (see ``singletons``) are
+    flattened, removing an unnecessary level of nesting.
+    """
+
+    mixins: tp.ClassVar = {
+        "CaloJet02": "Jet",
+        "CaloJet04": "Jet",
+        "CaloJet08": "Jet",
+        "CaloJet15": "Jet",
+        "EFlowNeutralHadron": "Tower",
+        "EFlowPhoton": "Photon",
+        "EFlowTrack": "Track",
+        "Electron": "Electron",
+        "ElectronCHS": "Electron",
+        "GenJet": "Jet",
+        "GenJet02": "Jet",
+        "GenJet04": "Jet",
+        "GenJet08": "Jet",
+        "GenJetAK8": "Jet",
+        "GenJet15": "Jet",
+        "GenMissingET": "MissingET",
+        "GenPileUpMissingET": "MissingET",
+        "Jet": "Jet",
+        "JetAK8": "Jet",
+        "JetPUPPI": "Jet",
+        "FatJet": "Jet",
+        "JetPUPPIAK8": "Jet",
+        "MissingET": "MissingET",
+        "PuppiMissingET": "MissingET",
+        "Muon": "Muon",
+        "MuonTight": "Muon",
+        "MuonLoose": "Muon",
+        "MuonTightCHS": "Muon",
+        "MuonLooseCHS": "Muon",
+        "Particle": "Particle",
+        "ParticleFlowJet02": "Jet",
+        "ParticleFlowJet04": "Jet",
+        "ParticleFlowJet08": "Jet",
+        "ParticleFlowJet15": "Jet",
+        "Photon": "Photon",
+        "PhotonCHS": "Photon",
+        "Tower": "Tower",
+        "Track": "Track",
+        "TrackJet02": "Jet",
+        "TrackJet04": "Jet",
+        "TrackJet08": "Jet",
+        "TrackJet15": "Jet",
+        "Weight": "Weight",
+        "WeightLHEF": "WeightLHEF",
+        # the following are also singletons
+        "Event": "Event",
+        "EventLHEF": "EventLHEF",
+        "HepMCEvent": "HepMCEvent",
+        "LHCOEvent": "LHCOEvent",
+        "Rho": "Rho",
+        "ScalarHT": "ScalarHT",
+    }
+    """Default configuration for mixin types, based on the collection name."""
+
+    # These are stored as length-1 vectors unnecessarily
+    singletons: tp.ClassVar = [
+        "Event",
+        "EventLHEF",
+        "HepMCEvent",
+        "LHCOEvent",
+        "Rho",
+        "ScalarHT",
+        "MissingET",
+    ]
+    """Fields stored as length-1 vectors in Delphes, flattened out in nanoevents."""
+
+    def __init__(self, version="latest"):
+        self._version = version
+
+    def __call__(self, array: awkward.Array) -> awkward.Array:
+        fields = list(array.fields)
+        n_events = int(awkward.num(array, axis=0))
+        forms = {f: _non_materializing_get_field(array, f) for f in fields}
+
+        # collections are the branch prefixes, excluding the counts branches
+        collections = {k.split(".")[0] for k in fields}
+        collections -= {k for k in collections if k.endswith("_size")}
+        # every real collection has a matching counts branch
+        collections = {c for c in collections if (c + "_size") in forms}
+
+        output = {}
+        for name in sorted(collections):
+            size = forms[name + "_size"]
+            offsets = counts2offsets(size)
+            mixin = self.mixins.get(name, "NanoCollection")
+
+            content = {}
+            for k in fields:
+                if k.startswith(name + "."):
+                    c = _jagged_content(forms[k])
+                    # convert ROOT TLorentzVector leaves to LorentzVector records
+                    converted = _lorentz_from_tlv(c)
+                    if converted is not None:
+                        c = converted
+                    # reduce ROOT TRef leaves to just their ``ref`` member
+                    stripped = _strip_tref(c)
+                    if stripped is not None:
+                        c = stripped
+                    content[k[len(name) + 1 :]] = c
+
+            # add aliases expected by the vector/candidate behaviors
+            if mixin == "MissingET":
+                content["rho"] = met_to_rho(content["MET"], content["Eta"])
+                content["eta"] = content["Eta"]
+                content["phi"] = content["Phi"]
+            elif mixin == "Vertex":
+                content["t"] = content["T"]
+                content["x"] = content["X"]
+                content["y"] = content["Y"]
+                content["z"] = content["Z"]
+            elif mixin in ("Particle", "Jet", "Track"):
+                content.pop("E", None)
+                content["pt"] = content["PT"]
+                content["eta"] = content["Eta"]
+                content["phi"] = content["Phi"]
+                content["mass"] = content["Mass"]
+            elif mixin in ("MasslessParticle", "Photon", "Electron", "Muon", "Tower"):
+                content.pop("E", None)
+                if "PT" not in content and "ET" in content:
+                    content["PT"] = content["ET"]
+                content["pt"] = content["PT"]
+                content["eta"] = content["Eta"]
+                content["phi"] = content["Phi"]
+                content["mass"] = full_like_from_counts(size, 0.0).layout.content
+
+            # handle branch names like Edges[4] and Tau[5]
+            content = {
+                k.replace("[", "_").replace("]", ""): v for k, v in content.items()
+            }
+
+            _content = tuple(content.values())
+            _fields = tuple(content.keys())
+            # some ROOT leaves (e.g. fBits) carry an over-sized data buffer; the
+            # collection offsets define the real item count, so set the record
+            # length from offsets[-1] and let longer contents be truncated
+            record = awkward.contents.RecordArray(
+                _content,
+                _fields,
+                length=_total_items(offsets),
+                parameters={"__record__": mixin, "collection_name": name},
+            )
+
+            # companion offsets field (matches coffea; truncated to n_events)
+            output[name + ".offsets"] = awkward.contents.NumpyArray(offsets)
+
+            if name in self.singletons:
+                # flatten: promote the (length-1) inner record up one level
+                output[name] = record
+            else:
+                output[name] = awkward.contents.ListOffsetArray(
+                    offsets=awkward.index.Index(offsets), content=record
+                )
+
+        contents = tuple(output.values())
+        names = tuple(output.keys())
+        nanoevents = awkward.Array(
+            awkward.contents.RecordArray(contents, names, length=n_events),
+            behavior=self.behavior(),
+        )
+        nanoevents = awkward.with_name(_rewrap(nanoevents), name="NanoEvents")
+        nanoevents.layout.parameters.update({"metadata": {"version": self._version}})
+        nanoevents.attrs["@original_array"] = nanoevents
+        return nanoevents
+
+    @classmethod
+    def behavior(cls):
+        """Behaviors necessary to implement this schema (dict)"""
+        from awkward_zipper.behaviors import delphes
+
+        return delphes.behavior

--- a/tests/test_delphes.py
+++ b/tests/test_delphes.py
@@ -1,0 +1,91 @@
+import awkward
+import uproot
+from coffea.nanoevents import DelphesSchema, NanoEventsFactory
+
+from awkward_zipper import Delphes
+
+file_name = "tests/samples/delphes.root"
+tree_name = "Delphes"
+
+# --- eager ---
+array = uproot.open(file_name)[tree_name].arrays(ak_add_doc=True)
+zipper_array = Delphes()(array)
+coffea_array = NanoEventsFactory.from_root(
+    {file_name: tree_name}, schemaclass=DelphesSchema, mode="eager"
+).events()
+
+# --- virtual ---
+access_log_zipper = []
+array_virtual = uproot.open(file_name)[tree_name].arrays(
+    virtual=True,
+    ak_add_doc={"__doc__": "title", "typename": "typename"},
+    access_log=access_log_zipper,
+)
+zipper_array_virtual = Delphes()(array_virtual)
+construction_access_log = list(access_log_zipper)
+
+coffea_array_virtual = NanoEventsFactory.from_root(
+    {file_name: tree_name}, schemaclass=DelphesSchema, mode="virtual"
+).events()
+
+
+def test_delphes_whole_eager():
+    assert awkward.array_equal(
+        zipper_array, coffea_array, check_parameters=False, equal_nan=True
+    )
+
+
+def test_delphes_whole_virtual():
+    assert awkward.array_equal(
+        zipper_array_virtual,
+        coffea_array_virtual,
+        check_parameters=False,
+        equal_nan=True,
+    )
+
+
+def test_no_data_materialization():
+    # offsets buffers may be touched during construction (to be tightened later),
+    # but no heavy *data* buffers should be materialized while building the layout
+    data_accesses = [
+        a for a in construction_access_log if a.buffer_key.endswith("-data")
+    ]
+    assert len(data_accesses) == 0
+
+
+def test_lorentz_and_tref_conversions():
+    # ROOT TLorentzVector leaves become LorentzVector records
+    assert set(zipper_array.Jet.Area.fields) == {"x", "y", "z", "t"}
+    # ROOT TRef leaves are reduced to their `ref` member (matches coffea)
+    assert zipper_array.Electron.Particle.fields == ["ref"]
+
+
+def test_singletons_flattened():
+    # length-1 vector collections are flattened (25 * event, not 25 * var * event)
+    assert str(awkward.type(zipper_array.MissingET)).endswith("missingET")
+    assert awkward.array_equal(
+        zipper_array.MissingET.rho,
+        coffea_array.MissingET.rho,
+        check_parameters=False,
+        equal_nan=True,
+    )
+
+
+def test_behaviors():
+    diff = set(coffea_array.behavior) - set(zipper_array.behavior)
+    for behavior in diff.copy():
+        if any(
+            string in str(behavior)
+            for string in ("Systematic", "UpDownSystematic", "UpDownMultiSystematic")
+        ):
+            diff.remove(behavior)
+    assert len(diff) == 0
+
+
+if __name__ == "__main__":
+    test_delphes_whole_eager()
+    test_delphes_whole_virtual()
+    test_no_data_materialization()
+    test_lorentz_and_tref_conversions()
+    test_singletons_flattened()
+    test_behaviors()

--- a/tests/test_delphes.py
+++ b/tests/test_delphes.py
@@ -44,13 +44,10 @@ def test_delphes_whole_virtual():
     )
 
 
-def test_no_data_materialization():
-    # offsets buffers may be touched during construction (to be tightened later),
-    # but no heavy *data* buffers should be materialized while building the layout
-    data_accesses = [
-        a for a in construction_access_log if a.buffer_key.endswith("-data")
-    ]
-    assert len(data_accesses) == 0
+def test_no_materialization():
+    # construction is fully lazy: no buffers (neither offsets/Index nor data)
+    # are materialized while building the layout
+    assert len(construction_access_log) == 0
 
 
 def test_lorentz_and_tref_conversions():
@@ -85,7 +82,7 @@ def test_behaviors():
 if __name__ == "__main__":
     test_delphes_whole_eager()
     test_delphes_whole_virtual()
-    test_no_data_materialization()
+    test_no_materialization()
     test_lorentz_and_tref_conversions()
     test_singletons_flattened()
     test_behaviors()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Array-based port of coffea's `DelphesSchema`.

- `{name}_size` counts -> offsets; per-collection jagged records with vector aliases (`pt`/`eta`/`phi`/`mass`, MET `rho`)
- ROOT `TLorentzVector` leaves converted to `LorentzVector`; `TRef` leaves reduced to `ref`
- length-1 singleton collections flattened

Matches coffea in eager + virtual; zero materialization (asserted in tests).

Based on `update-nanoaod-4vectors` (#21).