### PR TITLE
fix: only publish sphinx docs to gh-pages from main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: Build-sphinx-docs
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -36,5 +40,6 @@ jobs:
         run: |
           make html
       - name: Run ghp-import
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           ghp-import -n -p -f docs/_build/html


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Build-sphinx-docs` runs on `pull_request` and force-pushes the built HTML to `gh-pages` unconditionally, so every PR build publishes to the live docs site and concurrent PR runs race each other for the ref:

```
! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages': is at f494270... but expected 5382019...)
```

- guard the `ghp-import` step with `github.event_name == 'push' && github.ref == 'refs/heads/main'` — PRs still build the docs (so breakage is caught), they just no longer publish
- add a `concurrency` group, matching `ci.yml`

Fixes the failing docs job on #22 and #26.