### PR TITLE
ci: test on Python 3.14 and 3.14t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         runs-on: [ubuntu-latest] # can be extended to other OSes, e.g. macOS/Windows if needed
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 exclude: ^(docs/notebooks|docs/benchmarks|docs/requirements.txt)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v5.0.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -21,14 +21,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.4"
+    rev: "v0.15.22"
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.4
+    rev: v0.15.22
     hooks:
       - id: ruff-format
 
@@ -43,24 +43,24 @@ repos:
   #         - pytest
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.10.0.1"
+    rev: "v0.11.0.1"
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.19.1"
+    rev: "1.20.0"
     hooks:
       - id: blacken-docs
         additional_dependencies:
           - black==22.12.0
 
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2025.04.07
+    rev: 2026.07.17
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.32.1
+    rev: 0.37.4
     hooks:
       - id: check-readthedocs
       - id: check-github-workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 1 - Unstable",
     "Topic :: Scientific/Engineering",
     "Typing :: Typed",
 ]
@@ -63,10 +65,6 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = false
 ignore_missing_imports = true
 
-[tool.uv]
-# `yarl` (v1.24.0) doesn't support CPython 3.11 (`cp311`) right now
-constraint-dependencies = ["yarl<1.24.0"]
-
 [tool.ruff.lint]
 ignore = [
     "PLR",  # Design related pylint codes
@@ -74,6 +72,8 @@ ignore = [
     # "B006",   # converts default args to 'None'
     "I002",   # isort: "from __future__ import annotations"
     "ISC001", # flake8-implicit-str-concat: Implicit string concatenation"
+    "PLC0415", # `import` should be at the top-level of a file
+    "RUF059",  # Unpacked variable is never used
 ]
 select = [
     "E",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: Free Threading :: 1 - Unstable",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Scientific/Engineering",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds Python 3.14 and 3.14t (free-threaded) to the CI matrix, plus the matching trove classifiers.

**Dropped the `[tool.uv]` yarl constraint.** It pinned `yarl<1.24.0` because 1.24.0 shipped no cp311 wheels — a packaging bug in that one release. 1.24.5 ships 17, so the constraint is obsolete. yarl is only ever transitive (`aiohttp` → `yarl<2.0,>=1.17.0`).

**Lint config.** The pre-commit autoupdate (ruff v0.11.4 → v0.15.22) enables two new rules that fail on existing code, so both are ignored: `PLC0415` (the `behavior()` classmethods defer their import so importing a layout doesn't pull in the numba-heavy behaviors modules) and `RUF059` (in `behaviors/`, which is copied verbatim from coffea). Also renamed the `ruff` hook to `ruff-check`, since `ruff` is now a deprecated alias.

**On 3.14t:** the free-threaded ABI is fully covered — numba, llvmlite, numpy and awkward-cpp all publish `cp314t` wheels. Note the GIL is still re-enabled at runtime: `import uproot` eagerly imports `cramjam`, which doesn't declare it can run without the GIL. awkward, numpy, numba and coffea all keep it disabled. So the job verifies we install and pass on the free-threaded build rather than that we run GIL-free. Classified as `Free Threading :: 2 - Beta`.
